### PR TITLE
Add performance test for Search Sync.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,18 @@ env:
   NOTIFICATIONS_URL: http://127.0.0.1:8080
   PEEWEE_URL: postgres://postgres:@localhost/pacifica_metadata
   ADMIN_USER_ID: 10
+  CACHE_SIZE: 0
 ".script": &1
 - pip install .
 - export POLICY_CPCONFIG="$PWD/server.conf"
 - cd tests
-- coverage run --include='*/site-packages/pacifica/policy/*' -m pytest -xv
+- coverage run --include='*/site-packages/pacifica/policy/*' -m pytest -xsv
 - coverage report -m --fail-under 100
 ".before_script": &2
 - psql -c 'create database pacifica_metadata;' -U postgres
 - export METADATA_CPCONFIG="$PWD/travis/server.conf"
 - pacifica-metadata-cmd dbsync
-- pushd tests; python -m pacifica.metadata & echo $! > metadata.pid; popd;
+- pushd tests; python -m pacifica.metadata > metadata-server.log 2>&1 & echo $! > metadata.pid; popd;
 - |
   MAX_TRIES=60
   HTTP_CODE=$(curl -sL -w "%{http_code}\\n" localhost:8121/keys -o /dev/null || true)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ environment:
   METADATA_URL: http://127.0.0.1:8121
   STATUS_URL: http://127.0.0.1:8121/keys?_id=104
   ADMIN_USER_ID: 10
+  CACHE_SIZE: 0
   matrix:
   - PYTHON: C:\Python27-x64
   - PYTHON: C:\Python36-x64

--- a/pacifica/policy/search/projects.py
+++ b/pacifica/policy/search/projects.py
@@ -73,9 +73,9 @@ class ProjectsRender(SearchBase):
     @classmethod
     def release(cls, **proj_obj):
         """Return whether the project has released anything."""
-        for trans_id in cls._transsip_transsap_merge({'project': proj_obj['_id']}, '_id'):
-            if cls.get_rel_by_args('transaction_user', transaction=trans_id, relationship=cls.releaser_uuid):
-                return 'true'
+        results = cls.get_rel_by_args('projects', _id=proj_obj['_id'])
+        if results and results[0].get('accepted_date', False):
+            return 'true'
         return 'false'
 
     @classmethod

--- a/pacifica/policy/search_sync.py
+++ b/pacifica/policy/search_sync.py
@@ -11,9 +11,9 @@ except ImportError:  # pragma: no cover
     from queue import Queue
 from math import ceil
 from datetime import datetime
+from six import text_type
 import requests
 from elasticsearch import Elasticsearch, ElasticsearchException, helpers
-from six import text_type
 from .config import get_config
 from .root import Root
 from .search_render import ELASTIC_INDEX, SearchRender

--- a/tests/admin_cmd_test.py
+++ b/tests/admin_cmd_test.py
@@ -229,13 +229,14 @@ class TestPerformanceSearchSync(TestCase):
         resp = ProjectsRender.get_transactions(_id='1238')
         end_time = time()
         self.assertEqual(len(resp), 10000)
-        self.assertTrue(end_time - start_time < 1)
+        self.assertTrue(end_time - start_time < 1,
+                        'The task took to long {} >= 1 second'.format(end_time - start_time))
 
     def test_project_release(self):
         """Test getting a projects release state is performant."""
         start_time = time()
-        resp = ProjectsRender.release(_id='1238')
+        resp = ProjectsRender.release(_id=u'666c\u00e9')
         end_time = time()
         self.assertEqual(resp, 'false')
-        self.assertTrue(end_time - start_time < 250,
-                        'The task took to long {} >= 250 seconds'.format(end_time - start_time))
+        self.assertTrue(end_time - start_time < 1,
+                        'The task took to long {} >= 1 second'.format(end_time - start_time))

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Common server setup code for CherryPy testing."""
-import logging
+# import logging
 from json import dumps, loads
 import cherrypy
 from pacifica.policy.root import Root, error_page_default
@@ -26,9 +26,9 @@ class CommonCPSetup(object):
     @staticmethod
     def setup_server():
         """Setup each test by starting the CherryPy server."""
-        logger = logging.getLogger('urllib2')
-        logger.setLevel(logging.DEBUG)
-        logger.addHandler(logging.StreamHandler())
+        # logger = logging.getLogger('urllib2')
+        # logger.setLevel(logging.DEBUG)
+        # logger.addHandler(logging.StreamHandler())
         cherrypy.config.update({'error_page.default': error_page_default})
         cherrypy.config.update(CHERRYPY_CONFIG)
         cherrypy.tree.mount(Root(), '/', CHERRYPY_CONFIG)


### PR DESCRIPTION
### Description

This adds a basic test against the transactions of a project. The
test generates 10k transactions associated with a project. Then
the timing of rendering a project for search can be checked.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #96 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
