### PR TITLE
Fix #102 Add LRU Cache to `get_config()`

### DIFF
--- a/pacifica/policy/admin.py
+++ b/pacifica/policy/admin.py
@@ -162,7 +162,7 @@ class AdminPolicy(object):
         return len(object_is_valid) > 0
 
     def _is_admin(self, user_id):
-        amember_query = '{0}/user_group?group={1}&person={2}'.format(
+        amember_query = '{0}/user_group?group={1}&user={2}'.format(
             self.md_url,
             self.admin_group_id,
             user_id

--- a/pacifica/policy/config.py
+++ b/pacifica/policy/config.py
@@ -6,9 +6,14 @@ try:
     from ConfigParser import SafeConfigParser
 except ImportError:  # pragma: no cover python 2 vs 3 issue
     from configparser import ConfigParser as SafeConfigParser
+try:
+    from functools import lru_cache
+except ImportError:  # pragma: no cover python 2 vs 3 issue
+    from backports.functools_lru_cache import lru_cache
 from pacifica.policy.globals import CONFIG_FILE
 
 
+@lru_cache(maxsize=1)
 def get_config():
     """
     Return the ConfigParser object with defaults set.


### PR DESCRIPTION
### Description

This adds the lru_cache decorator to the `get_config()` method
so it will cache the results of the config instead of reading the
configfile over and over again.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #102 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
