### PR TITLE
Adds custodian based information to the available projects list for a user

### DIFF
--- a/pacifica/policy/status/base.py
+++ b/pacifica/policy/status/base.py
@@ -15,5 +15,8 @@ class QueryBase(AdminPolicy):
     all_transactions_url = '{0}/transactions'.format(md_url)
 
     def _get_available_projects(self, user_id):
-        return self._projects_for_user(user_id)
+        user_projects = self._projects_for_user(user_id)
+        custodian_projects = self._projects_for_custodian(user_id)
+
+        return list(set().union(user_projects, custodian_projects))
 # pylint: enable=too-few-public-methods


### PR DESCRIPTION
### Description
Minor tweak to add custodian-level information to the list of available projects for a user

### Issues Resolved

Fixes #121 

### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
